### PR TITLE
Launch Window

### DIFF
--- a/.config/webpack/webpack.config.prod.renderer.ts
+++ b/.config/webpack/webpack.config.prod.renderer.ts
@@ -16,6 +16,8 @@ import checkNodeEnv from '../script/check-node-env';
 
 checkNodeEnv('production');
 
+const isDevelopmentMode = process.env.NODE_ENV === `development`;
+
 const devtoolsConfig =
   process.env.DEBUG_PROD === `true`
     ? {
@@ -32,10 +34,11 @@ export default webpackMergeConfig(baseConfig, {
 
   entry: {
     renderer: pathJoin(webpackPaths.srcRendererPath, `index.tsx`),
+    launch: pathJoin(webpackPaths.srcRendererPath, `launch`, `launch.tsx`),
   },
 
   output: {
-    filename: `renderer.js`,
+    filename: `[name].js`,
     path: webpackPaths.distRendererPath,
     publicPath: './',
   },
@@ -75,13 +78,25 @@ export default webpackMergeConfig(baseConfig, {
     new HtmlWebpackPlugin({
       filename: 'index.html',
       template: pathJoin(webpackPaths.srcRendererPath, 'index.html'),
+      chunks: [`renderer`],
       minify: {
         collapseWhitespace: true,
         removeAttributeQuotes: true,
         removeComments: true,
       },
       isBrowser: false,
-      isDevelopment: process.env.NODE_ENV !== 'production',
+      isDevelopment: isDevelopmentMode,
+    }),
+
+    new HtmlWebpackPlugin({
+      filename: 'launch.html',
+      template: pathJoin(webpackPaths.srcRendererPath, `launch`, 'launch.html'),
+      chunks: [`launch`],
+      minify: {
+        collapseWhitespace: true,
+        removeAttributeQuotes: true,
+        removeComments: true,
+      },
     }),
   ],
 });

--- a/src/main/util.ts
+++ b/src/main/util.ts
@@ -12,10 +12,10 @@ import path from 'path';
 export let resolveHtmlPath: (htmlFileName: string) => string;
 
 if (process.env.NODE_ENV === 'development') {
+  // In DEVELOPMENT MODE
   const port = process.env.PORT || 1234;
 
   resolveHtmlPath = (htmlFileName: string) => {
-    // In DEVELOPMENT MODE
     const url = new URL(`http://localhost:${port}`);
     url.pathname = htmlFileName;
     return url.href;

--- a/src/renderer/launch/launch.html
+++ b/src/renderer/launch/launch.html
@@ -1,0 +1,42 @@
+<!--
+/**
+ * launch.html
+ * 
+ * Description:
+ *    Launch HTMl file. 
+ * 
+*/
+-->
+
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="
+        default-src 'none';
+        script-src 'self';
+        connect-src 'self';
+        img-src 'self';
+        style-src 'self' 'unsafe-inline';"
+    />
+    <meta
+      http-equiv="X-Content-Security-Policy"
+      content="
+        default-src 'none';
+        script-src 'self';
+        connect-src 'self';
+        img-src 'self';
+        style-src 'self' 'unsafe-inline';"
+    />
+  </head>
+  <body class="d-flex flex-column justify-content-center align-items-center">
+    <section
+      id="root"
+      class="d-flex flex-column justify-content-center align-items-center"
+    ></section>
+  </body>
+</html>

--- a/src/renderer/launch/launch.scss
+++ b/src/renderer/launch/launch.scss
@@ -1,0 +1,92 @@
+/**
+ * launch.css 
+ * 
+ * Description :
+ *    Launch window stylesheet.
+ * 
+ */
+
+/*
+ * Remove padding and margin
+ */
+html,
+body {
+  height: 100%;
+  width: 100%;
+  background: transparent;
+  cursor: default;
+}
+
+* {
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  position: relative;
+  min-height: 100vh;
+  width: 100%;
+  overflow: hidden;
+}
+
+/**
+ * Flex
+ */
+.d-flex {
+  display: flex;
+}
+
+.flex-column {
+  flex-flow: column;
+}
+
+.justify-content-center {
+  justify-content: center;
+}
+
+.align-items-center {
+  align-items: center;
+}
+
+section {
+  width: 100%;
+  height: 100%;
+  align-self: center;
+  border-radius: 24px;
+  background: rgba(0, 0, 0, 0.75);
+}
+
+/**
+ * Section
+ */
+section .img-section {
+  width: 100%;
+  height: 65%;
+}
+
+.img-section img {
+  position: relative;
+  height: 150px;
+  width: 150px;
+}
+
+.description-title,
+.description-content {
+  font-family: monospace;
+  color: white;
+  font-weight: bold;
+}
+
+.description-title {
+  width: 100%;
+  height: 20%;
+  font-size: 48px;
+  font-variant-caps: petite-caps;
+}
+
+.description-content {
+  width: 100%;
+  height: 15%;
+  font-size: 16px;
+  word-wrap: break-word;
+}

--- a/src/renderer/launch/launch.tsx
+++ b/src/renderer/launch/launch.tsx
@@ -1,0 +1,27 @@
+/**
+ * index.tsx
+ *
+ * Description:
+ *    Renderer process file for ELectron. This file on compilation will be
+ *    attached to `index.html`.
+ */
+
+import React from 'react';
+import { render } from 'react-dom';
+import './launch.scss';
+import IMAGE from '../../assets/images/logo/Notes_Logo_250.png';
+
+render(
+  <>
+    <div className="img-section d-flex justify-content-center align-items-center">
+      <img src={IMAGE} alt="Logo" />
+    </div>
+    <div className="description-title d-flex flex-column justify-content-center align-items-center">
+      <span> Notes </span>
+    </div>
+    <div className="description-content d-flex flex-column justify-content-center align-items-center">
+      <span> Developed by Vedant Wakalkar </span>
+    </div>
+  </>,
+  document.getElementById(`root`)
+);


### PR DESCRIPTION
### Description

Added the launch window for the Notes Application.

### Additional Context

The window shows the Notes Application Logo, Name and "Developed by .." text. The "Developed by .." text can be removed or updated moving forward if contributions started contributing to this project.

- In DEVELOPMENT Mode, 
    The launch window will not be launched and the main application will be shown. This will help to cut down the wait around time for the launch window during DEVELOPMENT mode. 

    If the Launch window needs to be tested in DEVELOPMENT  mode, a small change is to be made in logic where the condition is checked for the launch window to be created and shown or not.
    ```
    # src/main/main.ts

    this.mainWindow.once('ready-to-show', () => {
          if (!isDevelopmentMode) {       // <-- Remove the "!" to change the logic
            // Only PRODUCTION Mode
            launcherWindow();
    ```

- In PRODUCTION Mode, 
    The launch window will always be shown in Production Mode.

    **_Note:_** When enabling the launch window in DEVELOPMENT Mode, it will disable the launch window in production mode, hence the updated logic should be reverted back to the original logic.

### Related Issues 
- #6 