### PR TITLE
Invalid time for Note's "last updated at".

### DIFF
--- a/src/renderer/Components/Notes/Note.tsx
+++ b/src/renderer/Components/Notes/Note.tsx
@@ -89,7 +89,7 @@ const Note = () => {
           <b>Last Updated at: </b>
           {currentNote &&
             new Date(currentNote.updated_at).toLocaleString('en-IN', {
-              hour12: false,
+              hourCycle: 'h23',
             })}
         </p>
         <Form


### PR DESCRIPTION
### Description
Refering to [link](https://stackoverflow.com/questions/68646411/date-tolocalestringen-us-hour12-false-is-providing-midnight-as-24)
One of the solutions was to set `hourcycle: 'h23'`

**Outcome**
![image](https://user-images.githubusercontent.com/32186983/150596391-d6580922-1ed7-4d1a-96a6-305e91c652f7.png)


### Related Issues:
- #41  
